### PR TITLE
improvement: store previous appointments df and only send emails when it changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 venv/
 .idea/
 config.yml
+apointments_df.csv


### PR DESCRIPTION
We should only send emails when the appointments actually change to reduce spam.